### PR TITLE
Fix credentials error with local service

### DIFF
--- a/src/services.js
+++ b/src/services.js
@@ -156,6 +156,7 @@ function main() {
     // eslint-disable-next-line
     console.log('Using local Deepstream server.');
     settings.communication.host_ip = 'localhost:60020';
+    settings.communication.credentials_url = undefined;
   }
   const service = createService(
     settings.communication.host_ip,


### PR DESCRIPTION
* Fixes a bug where services didn't work locally since it verified the credentials from a local server that is not running local. It only exists in the backend